### PR TITLE
Additional tracking codes #qjrcw

### DIFF
--- a/app/views/layouts/buttercms/default.html.erb
+++ b/app/views/layouts/buttercms/default.html.erb
@@ -1,6 +1,23 @@
 <!DOCTYPE html>
 <html prefix="og: http://ogp.me/ns#" lang="en">
 <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-53276411-1"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-53276411-1');
+    </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-TZK32GR');</script>
+    <!-- End Google Tag Manager -->
+
     <title><%= (content_for?(:html_title) ? "#{content_for(:html_title)} | Bitrise Blog" : "Bitrise Blog").html_safe %></title>
 
     <meta name="description" content="<%= content_for?(:meta_description) ? content_for(:meta_description) : "Articles about Continuous Integration & Delivery, automation, iOS code signing, DevOps, and awesome tech" %>">
@@ -40,6 +57,10 @@
 
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TZK32GR"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
 
   <%= render :partial => 'navigation' %>
   <%= render :partial => 'categories' %>


### PR DESCRIPTION
Some subdomains are missing some or all the tracking codes. This prevents the growth team to use that data for further enhancement of ads and work in general. 